### PR TITLE
Allow import of multiple packages

### DIFF
--- a/importall/main.py
+++ b/importall/main.py
@@ -12,19 +12,22 @@ def main(argv: Optional[List[str]] = None) -> None:
         "--exclude", default="tests", help="comma-separated directories to ignore"
     )
     parser.add_argument("--root", help="Search under this dir")
-    parser.add_argument("package", metavar="PACKAGE", help="Name of package to test")
+    parser.add_argument("package", nargs='+', metavar="PACKAGE", help="Name of package(s) to test")
     args = parser.parse_args(argv)
 
-    assert "." not in args.package, "give top level package name"
     if args.root:
         sys.path.insert(0, args.root)
 
-    filename = __import__(args.package).__file__
-    assert filename is not None, "namespace packages not supported"
-    assert filename.endswith("__init__.py"), "single modules not supported"
-
     exclude_set = set(args.exclude.split(","))
-    base_path = Path(filename).parent.parent
-    for name in sorted(find_importable_names(base_path, args.package, exclude_set)):
-        __import__(name)
-        print(f"{name} ok")
+
+    for package in args.package:
+        assert "." not in package, f"{package}: give top level package name"
+
+        filename = __import__(package).__file__
+        assert filename is not None, f"{package}: namespace packages not supported"
+        assert filename.endswith("__init__.py"), f"{package}: single modules not supported"
+
+        base_path = Path(filename).parents[1]
+        for name in sorted(find_importable_names(base_path, package, exclude_set)):
+            __import__(name)
+            print(f"{name} ok")

--- a/importall/main.py
+++ b/importall/main.py
@@ -12,7 +12,9 @@ def main(argv: Optional[List[str]] = None) -> None:
         "--exclude", default="tests", help="comma-separated directories to ignore"
     )
     parser.add_argument("--root", help="Search under this dir")
-    parser.add_argument("package", nargs='+', metavar="PACKAGE", help="Name of package(s) to test")
+    parser.add_argument(
+        "package", nargs="+", metavar="PACKAGE", help="Name of package(s) to test"
+    )
     args = parser.parse_args(argv)
 
     if args.root:
@@ -25,7 +27,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
         filename = __import__(package).__file__
         assert filename is not None, f"{package}: namespace packages not supported"
-        assert filename.endswith("__init__.py"), f"{package}: single modules not supported"
+        assert filename.endswith(
+            "__init__.py"
+        ), f"{package}: single modules not supported"
 
         base_path = Path(filename).parents[1]
         for name in sorted(find_importable_names(base_path, package, exclude_set)):

--- a/importall/tests/main.py
+++ b/importall/tests/main.py
@@ -48,7 +48,7 @@ importall.main ok
             output,
         )
 
-    def test_ok(self) -> None:
+    def test_single_modules_ok(self) -> None:
         with volatile.dir() as d:
             pd = Path(d)
             (pd / "fake_module").mkdir()
@@ -65,6 +65,26 @@ importall.main ok
             """\
 fake_module ok
 fake_module.x ok
+""",
+            output,
+        )
+        self.assertEqual(None, err)
+
+    def test_multiple_modules_ok(self) -> None:
+        with volatile.dir() as d:
+            pd = Path(d)
+            (pd / "fake_module_1").mkdir()
+            (pd / "fake_module_1" / "__init__.py").write_text("")
+
+            (pd / "fake_module_2").mkdir()
+            (pd / "fake_module_2" / "__init__.py").write_text("")
+
+            output, err = self.do_run([f"--root={d}", "fake_module_1", "fake_module_2"])
+
+        self.assertEqual(
+            """\
+fake_module_1 ok
+fake_module_2 ok
 """,
             output,
         )


### PR DESCRIPTION
**PR Summary**
Closes #1 
- make `ArgumentParser` accept a list of packages
- change the logic in `main.py` to work with a list of packages
- write a test in `tests/main.py` with a multiple packages scenario
